### PR TITLE
make run_from_par run in parallel

### DIFF
--- a/.github/r_scripts/run_from_par.R
+++ b/.github/r_scripts/run_from_par.R
@@ -1,4 +1,10 @@
 # code to run the ss_new models
+list.of.packages <- c("parallely", "furrr", "future")
+new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
+if(length(new.packages)>0) install.packages(new.packages)
+
+ncores <- parallelly::availableCores() - 1
+future::plan(future::multisession, workers = ncores)
 
 mod_names <- list.dirs("model_runs", full.names = FALSE, recursive = FALSE)
 mod_paths <- list.dirs("model_runs", full.names = TRUE, recursive = FALSE)
@@ -36,9 +42,10 @@ run_ss_noest <- function(dir) {
         }
 }
 
-mod_ran <- lapply(mod_paths, function(x) tryCatch(run_ss_noest(x), 
+mod_ran <- furrr::future_map(mod_paths, function(x) {tryCatch(run_ss_noest(x), 
                                        error = function(e) print(e)
-                                       )
+                                       )}
+
            )
 mod_errors <- mod_names[unlist(lapply(mod_ran, function(x) "simpleError" %in% class(x)))]
 success <- TRUE

--- a/.github/r_scripts/run_from_par.R
+++ b/.github/r_scripts/run_from_par.R
@@ -3,7 +3,7 @@ list.of.packages <- c("parallely", "furrr", "future")
 new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
 if(length(new.packages)>0) install.packages(new.packages)
 
-ncores <- parallelly::availableCores() - 1
+ncores <- parallelly::availableCores(omit = 1)
 future::plan(future::multisession, workers = ncores)
 
 mod_names <- list.dirs("model_runs", full.names = FALSE, recursive = FALSE)


### PR DESCRIPTION
Updating run_from_par.R file to run in parallel using the {furrr} package. This r code is used the the [test-r4ss-with-ss3 workflow](https://github.com/nmfs-ost/ss3-source-code/blob/main/.github/workflows/test-r4ss-with-ss3.yml) in the ss3-source-code repository.

See the successful run of the ss3-source-code workflow that uses this R code - https://github.com/nmfs-ost/ss3-source-code/actions/runs/7105167121. The branch run specifically pulls from the branch that I am wanting to merge here.

