### PR TITLE
Change SS3 download link to pre-release version for a test

### DIFF
--- a/.github/workflows/update-ss3-models.yml
+++ b/.github/workflows/update-ss3-models.yml
@@ -1,6 +1,7 @@
 name: update-ss3-test-models
 on: 
   workflow_dispatch:
+  push: 
 
 jobs:
   update-ss3-test-models:
@@ -36,7 +37,7 @@ jobs:
         
       - name: Get the latest SS3 executable
         run: |
-          wget -O ss3 https://github.com/nmfs-ost/ss3-source-code/releases/latest/download/ss3_linux
+          wget -O ss3 https://github.com/nmfs-ost/ss3-source-code/releases/tag/v3.30.25-prerel/download/ss3_linux
           sudo chmod a+x ss3
           mv ss3 /usr/local/bin/ss3
           export PATH=/usr/local/bin/ss3:$PATH


### PR DESCRIPTION
Updated the SS3 executable download link to the specific version v3.30.25-prerel.